### PR TITLE
Fix: use double quotes for haml-rails gem to satisfy RuboCop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem "turbo-rails"
 gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
-gem 'haml-rails'
+gem "haml-rails"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"


### PR DESCRIPTION
CI（Lint）の指摘を受け、`gem 'haml-rails'` を `gem "haml-rails"` に変更しました。